### PR TITLE
Fix WebAPI accesses to handle network error

### DIFF
--- a/app/models/currency_converter.rb
+++ b/app/models/currency_converter.rb
@@ -24,7 +24,7 @@ class CurrencyConverter
   class ConversionError < ::StandardError; end
 
   def self.currencies
-    @currencies ||= JSON.parse(OpenExchangeRatesClient.new.fetch_currencies(open_timeout: 10, read_timeout: 10))
+    @currencies ||= JSON.parse(OpenExchangeRatesClient.new.fetch_currencies)
   end
 
   def api_app_id=(app_id)
@@ -34,7 +34,7 @@ class CurrencyConverter
   def convert!
     validate!
 
-    ratio_mapping = JSON.parse(api_client.fetch_historical_for(date: date, open_timeout: 10, read_timeout: 10))
+    ratio_mapping = JSON.parse(api_client.fetch_historical_for(date: date))
     if ratio_mapping.blank?
       raise ConversionError, "Couldn't fetch historical ratio"
     end

--- a/app/models/currency_converter.rb
+++ b/app/models/currency_converter.rb
@@ -24,7 +24,7 @@ class CurrencyConverter
   class ConversionError < ::StandardError; end
 
   def self.currencies
-    @currencies ||= JSON.parse(OpenExchangeRatesClient.new.fetch_currencies)
+    @currencies ||= JSON.parse(OpenExchangeRatesClient.new.fetch_currencies(open_timeout: 10, read_timeout: 10))
   end
 
   def api_app_id=(app_id)
@@ -34,7 +34,10 @@ class CurrencyConverter
   def convert!
     validate!
 
-    ratio_mapping = JSON.parse(api_client.fetch_historical_for(date: date))
+    ratio_mapping = JSON.parse(api_client.fetch_historical_for(date: date, open_timeout: 10, read_timeout: 10))
+    if ratio_mapping.blank?
+      raise ConversionError, "Couldn't fetch historical ratio"
+    end
     if ratio_mapping.key?('error')
       raise ConversionError, ratio_mapping['description']
     end

--- a/app/models/open_exchange_rates_client.rb
+++ b/app/models/open_exchange_rates_client.rb
@@ -4,8 +4,6 @@ class OpenExchangeRatesClient
   include ActiveModel::Validations
   include ActiveModel::Attributes
 
-  DEFAULT_HTTP_ATTRIBUTES = { use_ssl: true }.freeze
-
   attribute :app_id, :string
 
   validates :app_id, presence: true
@@ -17,28 +15,27 @@ class OpenExchangeRatesClient
     )
   end
 
-  def fetch_currencies(**options)
+  def fetch_currencies
     currencies_url = base_url.tap do |url|
       url.path << '/currencies.json'
     end
-    fetch(currencies_url, options)
+    fetch(currencies_url)
   end
 
-  def fetch_historical_for(date:, **options)
+  def fetch_historical_for(date:)
     validate!
     historical_url = base_url.tap do |url|
       url.path << "/historical/#{date.to_date.strftime('%F')}.json"
       url.query = "app_id=#{app_id}"
     end
-    fetch(historical_url, options)
+    fetch(historical_url)
   end
 
   private
 
-  def fetch(uri, **options)
+  def fetch(uri)
     result = perform do
-      http_attributes = DEFAULT_HTTP_ATTRIBUTES.merge(options.symbolize_keys)
-      Net::HTTP.start(uri.host, uri.port, http_attributes) do |http|
+      Net::HTTP.start(uri.host, uri.port) do |http|
         request = Net::HTTP::Get.new(uri)
         response = http.request(request)
         response.value

--- a/app/models/open_exchange_rates_client.rb
+++ b/app/models/open_exchange_rates_client.rb
@@ -4,6 +4,8 @@ class OpenExchangeRatesClient
   include ActiveModel::Validations
   include ActiveModel::Attributes
 
+  DEFAULT_HTTP_ATTRIBUTES = { use_ssl: true }.freeze
+
   attribute :app_id, :string
 
   validates :app_id, presence: true
@@ -15,19 +17,63 @@ class OpenExchangeRatesClient
     )
   end
 
-  def fetch_currencies
+  def fetch_currencies(**options)
     currencies_url = base_url.tap do |url|
       url.path << '/currencies.json'
     end
-    Net::HTTP.get(currencies_url)
+    fetch(currencies_url, options)
   end
 
-  def fetch_historical_for(date:)
+  def fetch_historical_for(date:, **options)
     validate!
     historical_url = base_url.tap do |url|
       url.path << "/historical/#{date.to_date.strftime('%F')}.json"
       url.query = "app_id=#{app_id}"
     end
-    Net::HTTP.get(historical_url)
+    fetch(historical_url, options)
+  end
+
+  private
+
+  def fetch(uri, **options)
+    result = perform do
+      http_attributes = DEFAULT_HTTP_ATTRIBUTES.merge(options.symbolize_keys)
+      Net::HTTP.start(uri.host, uri.port, http_attributes) do |http|
+        request = Net::HTTP::Get.new(uri)
+        response = http.request(request)
+        response.value
+        response.body
+      end
+    end
+    result.is_a?(Exception) ? {}.to_json : result
+  end
+end
+
+class OpenExchangeRatesClient
+  concerning :Execution do
+    include ActiveSupport::Rescuable
+
+    included do
+      rescue_from Timeout::Error, SocketError, with: :handle_network_error
+      rescue_from Net::HTTPExceptions, with: :handle_net_http_error
+    end
+
+    def perform
+      yield
+    rescue Exception => exception
+      rescue_with_handler(exception) || raise
+    end
+
+    # ----- error handling -----
+
+    # TODO: implement handling error before deployment
+    def handle_network_error(exception)
+      # Rails.logger.error "#{exception.class}: #{exception.message}"
+    end
+
+    # TODO: implement handling error before deployment
+    def handle_net_http_error(exception)
+      # Rails.logger.error "#{exception.class}: #{exception.message}"
+    end
   end
 end

--- a/spec/models/currency_converter_spec.rb
+++ b/spec/models/currency_converter_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CurrencyConverter do
     subject { converter.convert! }
     let(:client) { build(:open_exchange_rates_client) }
     before(:each) do
-      allow(client).to receive(:fetch_historical_for).with(date: converter.date).and_return(load_json(converter.date.strftime('%F')))
+      allow(client).to receive(:fetch_historical_for).with(date: converter.date, open_timeout: 10, read_timeout: 10).and_return(load_json(converter.date.strftime('%F')))
       allow(converter).to receive(:api_client).and_return(client)
       allow(converter).to receive(:currencies).and_return(JSON.parse(load_json('currencies')))
     end

--- a/spec/models/currency_converter_spec.rb
+++ b/spec/models/currency_converter_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CurrencyConverter do
     subject { converter.convert! }
     let(:client) { build(:open_exchange_rates_client) }
     before(:each) do
-      allow(client).to receive(:fetch_historical_for).with(date: converter.date, open_timeout: 10, read_timeout: 10).and_return(load_json(converter.date.strftime('%F')))
+      allow(client).to receive(:fetch_historical_for).with(date: converter.date).and_return(load_json(converter.date.strftime('%F')))
       allow(converter).to receive(:api_client).and_return(client)
       allow(converter).to receive(:currencies).and_return(JSON.parse(load_json('currencies')))
     end

--- a/spec/models/open_exchange_rates_client_spec.rb
+++ b/spec/models/open_exchange_rates_client_spec.rb
@@ -14,4 +14,31 @@ RSpec.describe OpenExchangeRatesClient do
       it { is_expected.to include(app_id: "can't be blank") }
     end
   end
+
+  describe '#fetch_currencies' do
+    subject { client.fetch_currencies }
+    let(:net_http_mock) { class_double(Net::HTTP).as_stubbed_const }
+    let(:client) { build(:open_exchange_rates_client) }
+
+    context 'when fetched currencies data' do
+      let(:currencies_json) { load_json('currencies') }
+      before { allow(net_http_mock).to receive(:start).and_return(currencies_json) }
+      it { is_expected.to eq(currencies_json) }
+    end
+
+    context 'when Timeout::Error is raised' do
+      before { allow(net_http_mock).to receive(:start).and_raise(Timeout::Error) }
+      it { is_expected.to eq({}.to_json) }
+    end
+
+    context 'when Net::HTTPServerException is raised' do
+      before { allow(net_http_mock).to receive(:start).and_raise(Net::HTTPServerException.new('1.1', 503)) }
+      it { is_expected.to eq({}.to_json) }
+    end
+
+    context 'when RuntimeError is raised' do
+      before { allow(net_http_mock).to receive(:start).and_raise(RuntimeError) }
+      it { expect { subject }.to raise_error(RuntimeError) }
+    end
+  end
 end


### PR DESCRIPTION
Regarding this issue #20 

Used `ActiveSupport::Rescuable` to handle errors. `Net::HTTP.start` can cause `Timeout::Error`, `SocketError` and `Net::HTTPExceptions`, and this changes treat them gracefully.

I mentioned that we should handle errors by caller, but I reconsider that we should handle them in Api Client because I thought it was a role of Client. I would not like to care handling errors whenever I use this library.

By the way, I said that it will be great if we specify http attributes like timeout, but I omit it because I would not like to mix different implementation in one PR.